### PR TITLE
fix: remove broken DEPLOY.md link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,14 +188,7 @@ For local development, the app uses an in-memory KV mock — no Cloudflare accou
 
 ## Deployment
 
-driveTree deploys to Cloudflare Pages (free tier). See [DEPLOY.md](../DEPLOY.md) for the full step-by-step guide covering:
-
-- Google Drive API key setup
-- Cloudflare Pages project creation
-- KV namespace creation and binding
-- GitHub Actions CI/CD (automatic deploy on push)
-- Custom domain + free SSL
-- Security and cost breakdown
+driveTree deploys to Cloudflare Pages (free tier).
 
 ### Quick deploy
 


### PR DESCRIPTION
## Summary
- Removes the broken `[DEPLOY.md](../DEPLOY.md)` link and associated bullet list from the README
- The file exists outside the published repository directory, causing a 404

Closes #1

🤖 Generated with [Claude Code](https://claude.com/claude-code)